### PR TITLE
Replace calls to `ReloadFirearm( )` with new `ReloadFirearms( )`.

### DIFF
--- a/Base.rte/AI/CrabBehaviors.lua
+++ b/Base.rte/AI/CrabBehaviors.lua
@@ -79,7 +79,7 @@ function CrabBehaviors.LookForTargets(AI, Owner)
 		if AI.ReloadTimer:IsPastSimMS(8000) then	-- check if we need to reload
 			AI.ReloadTimer:Reset()
 			if Owner.FirearmNeedsReload then
-				Owner:ReloadFirearm()
+				Owner:ReloadFirearms()
 			end
 		end
 	end
@@ -536,7 +536,7 @@ function CrabBehaviors.ShootTarget(AI, Owner, Abort)
 			
 			ShootTimer:Reset()
 			if Owner.FirearmIsEmpty then
-				Owner:ReloadFirearm()
+				Owner:ReloadFirearms()
 				aimError = RangeRand(-0.14, 0.14) * AI.aimSkill
 				aimTime = RangeRand(220, 330) * AI.aimSpeed + 50
 				if Owner.FirearmActivationDelay > 0 then
@@ -681,7 +681,7 @@ function CrabBehaviors.ShootArea(AI, Owner, Abort)
 			AI.fire = false
 			
 			if Owner.FirearmIsEmpty then
-				Owner:ReloadFirearm()
+				Owner:ReloadFirearms()
 			end
 			
 			break -- stop this behavior when the mag is empty

--- a/Base.rte/AI/HumanBehaviors.lua
+++ b/Base.rte/AI/HumanBehaviors.lua
@@ -629,7 +629,7 @@ end
 function HumanBehaviors.GoldDig(AI, Owner, Abort)
 	-- make sure our weapon have ammo before we start to dig, just in case we encounter an enemy while digging
 	if Owner.EquippedItem and (Owner.FirearmNeedsReload or Owner.FirearmIsEmpty) and Owner.EquippedItem:HasObjectInGroup("Weapons") then
-		Owner:ReloadFirearm()
+		Owner:ReloadFirearms()
 		
 		repeat
 			local _ai, _ownr, _abrt = coroutine.yield()	-- wait until next frame
@@ -2578,7 +2578,7 @@ function HumanBehaviors.ShootTarget(AI, Owner, Abort)
 					-- we might have a different weapon equipped now check if FirearmIsEmpty again
 					if Owner.FirearmIsEmpty then
 						-- TODO: check if ducking is appropriate while reloading (when we can make the actor stand up reliably)
-						Owner:ReloadFirearm()
+						Owner:ReloadFirearms()
 						
 						-- increase the TargetLostTimer limit so we don't end this behavior before the reload is finished
 						if Owner.EquippedItem and IsHDFirearm(Owner.EquippedItem) then
@@ -2627,7 +2627,7 @@ function HumanBehaviors.ShootTarget(AI, Owner, Abort)
 	end
 	
 	if Owner.FirearmIsEmpty then
-		Owner:ReloadFirearm()
+		Owner:ReloadFirearms()
 	end
 	
 	return true
@@ -3066,7 +3066,7 @@ function HumanBehaviors.ShootArea(AI, Owner, Abort)
 			
 			ShootTimer:Reset()
 			if Owner.FirearmIsEmpty then
-				Owner:ReloadFirearm()
+				Owner:ReloadFirearms()
 			end
 			
 			break -- stop this behavior when the mag is empty

--- a/Base.rte/AI/NativeCrabAI.lua
+++ b/Base.rte/AI/NativeCrabAI.lua
@@ -171,7 +171,7 @@ function NativeCrabAI:Update(Owner)
 								end
 							else
 								if Owner.FirearmIsEmpty then
-									Owner:ReloadFirearm()
+									Owner:ReloadFirearms()
 								end
 							end
 						end
@@ -316,7 +316,7 @@ function NativeCrabAI:CreateAttackBehavior(Owner)
 		self.NextBehaviorName = "ShootTarget"
 	else
 		if Owner.FirearmIsEmpty then
-			Owner:ReloadFirearm()
+			Owner:ReloadFirearms()
 		end
 		
 		return
@@ -335,7 +335,7 @@ function NativeCrabAI:CreateSuppressBehavior(Owner)
 		self.NextBehaviorName = "ShootArea"
 	else
 		if self.FirearmIsEmpty then
-			self:ReloadFirearm()
+			self:ReloadFirearms()
 		end
 		
 		return

--- a/Base.rte/AI/NativeHumanAI.lua
+++ b/Base.rte/AI/NativeHumanAI.lua
@@ -318,7 +318,7 @@ function NativeHumanAI:Update(Owner)
 		if self.ReloadTimer:IsPastSimMS(8000) then	-- check if we need to reload
 			if Owner.FirearmNeedsReload then
 				self.ReloadTimer:Reset()
-				Owner:ReloadFirearm()
+				Owner:ReloadFirearms()
 			elseif not HumanBehaviors.EquipPreferredWeapon(self, Owner) then	-- make sure we equip a preferred or a primary weapon if we have one
 				self.ReloadTimer:Reset()
 			end
@@ -394,7 +394,7 @@ function NativeHumanAI:Update(Owner)
 											end
 										else
 											if Owner.FirearmIsEmpty then
-												Owner:ReloadFirearm()
+												Owner:ReloadFirearms()
 											elseif Owner.InventorySize > 0 and not Owner:EquipDeviceInGroup("Weapons - Primary", true) then
 												Owner:EquipFirearm(true)
 											end
@@ -800,7 +800,7 @@ function NativeHumanAI:CreateSuppressBehavior(Owner)
 		self.NextBehaviorName = "ShootArea"
 	else
 		if Owner.FirearmIsEmpty then
-			Owner:ReloadFirearm()
+			Owner:ReloadFirearms()
 		end
 		
 		return

--- a/Base.rte/AI/NativeTurretAI.lua
+++ b/Base.rte/AI/NativeTurretAI.lua
@@ -207,7 +207,7 @@ function NativeTurretAI:CreateAttackBehavior(Owner)
 		self.NextBehaviorName = "ShootTarget"
 	else
 		if Owner.FirearmIsEmpty then
-			Owner:ReloadFirearm()
+			Owner:ReloadFirearms()
 		end
 		
 		return
@@ -226,7 +226,7 @@ function NativeTurretAI:CreateSuppressBehavior(Owner)
 		self.NextBehaviorName = "ShootArea"
 	else
 		if Owner.FirearmIsEmpty then
-			self:ReloadFirearm()
+			self:ReloadFirearms()
 		end
 		
 		return


### PR DESCRIPTION
Renamed `ReloadFirearm( )` ->`ReloadFirearms( )`.
This fixes AHuman Actors AI not being able to reload.

Requires cortex-command-community/Cortex-Command-Community-Project-Source#319 to work, as it also affects the ACrab `ReloadFirearms( )`, which is yet to be added. This preempts the merge.