### PR TITLE
Change "How to Play" to "Install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This is where you can find the community's plans for Cortex Command's future. Th
 ***
 
 # Installing the Game
-If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io), and you can get mods from our [mod portal](https://cccp.mod.io).
+If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io).
+
+# Getting Mods
+You can get mods from our [mod portal](https://cccp.mod.io).
 
 ***
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is where you can find the community's plans for Cortex Command's future. Th
 
 ***
 
-# How to Play the Game
+# Installing the Game
 If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io), and you can get mods from our [mod portal](https://cccp.mod.io).
 
 ***

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is where you can find the community's plans for Cortex Command's future. Th
 ***
 
 # Installing the Game
-If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io).
+If you just want to play the latest version of the game you can get it from our [website](https://cortex-command-community.github.io/downloads).
 
 # Getting Mods
 You can get mods from our [mod portal](https://cccp.mod.io).


### PR DESCRIPTION
I have a friend who made the remark that "How to Play" implies a tutorial on how to beat the game, instead of being about how to install the game.