### PR TITLE
Nerfs Browncoat ushankas to their pre-pre4 state by removing the lifetime from their wound

### DIFF
--- a/Browncoats.rte/Effects/Wounds.ini
+++ b/Browncoats.rte/Effects/Wounds.ini
@@ -4,7 +4,6 @@
 
 AddEffect = AEmitter
 	PresetName = Wound Browncoat Hat
-	LifeTime = 10
 	Mass = 0.0001
 	HitsMOs = 0
 	GetsHitByMOs = 0


### PR DESCRIPTION
Title! Briefly discussed this in #project-balance in the Discord, but long story short, as of pre4, the ushankas of Browncoat lights are nigh-invulnerable to anything that isn't raw blunt force. Pretty much all small arms fire gets swallowed up by 'em, nullifying any bullet that dares land above a Browncoat light's visor.

This happens because the ushanka's only wound has a lifetime of a mere 10ms! Previously, this variable being defined did nothing, as the lifetime of wounds simply didn't matter. But now that wound lifetime exists as of pre4, suddenly ushankas are absurd bullet sponges, capable of regenerating back to full integrity in a single frame!

So this PR reverts ushankas back to their pre-pre4 state by making one simple change: removing the lifetime var entirely.