### PR TITLE
Drop ship hover height modifier

### DIFF
--- a/Base.rte/Craft/Dropships/DropshipMK1.ini
+++ b/Base.rte/Craft/Dropships/DropshipMK1.ini
@@ -1501,6 +1501,7 @@ AddActor = ACDropShip
 	StableRecoveryDelay = 500
 	ImpulseDamageThreshold = 15000
 	CharHeight = 100
+	HoverHeightModifier = -50
 	AddEmitter = AEmitter
 		CopyOf = Machine Gun Turret
 		ParentOffset = Vector

--- a/Dummy.rte/Craft/Dropships/Dropship.ini
+++ b/Dummy.rte/Craft/Dropships/Dropship.ini
@@ -1272,6 +1272,7 @@ AddActor = ACDropShip
 		X = 220
 		Y = 220
 	CharHeight = 100
+	HoverHeightModifier = -20
 	LThruster = AEmitter
 		CopyOf = Dummy Dropship Engine A Left
 		ParentOffset = Vector


### PR DESCRIPTION
- [x] Making dropship AI support hover height modifier
- [x] Making basegame dropships have a slight negative hover height modifier so they're less likely to damage their drops. They still damage them a bit sometimes so maybe the modifier should be made even smaller (more negative)