### PR TITLE
Update Hair.lua

### DIFF
--- a/Ronin.rte/Actors/Infantry/RoninLight/Hair.lua
+++ b/Ronin.rte/Actors/Infantry/RoninLight/Hair.lua
@@ -1,5 +1,5 @@
 function Update(self)
 	local pullForce = (self.Vel + self.PrevVel)/2 - SceneMan.GlobalAcc * rte.PxTravelledPerFrame;
 	self.RotAngle = pullForce.AbsRadAngle;
-	self.Frame = not pullForce:MagnitudeIsGreaterThan(8) and 1 or 0;
+	self.Frame = pullForce:MagnitudeIsLessThan(8) and 1 or 0;
 end

--- a/Ronin.rte/Actors/Infantry/RoninLight/Hair.lua
+++ b/Ronin.rte/Actors/Infantry/RoninLight/Hair.lua
@@ -1,5 +1,5 @@
 function Update(self)
-	local gravity = (self.Vel + self.PrevVel)/2 - SceneMan.GlobalAcc * rte.PxTravelledPerFrame;
-	self.RotAngle = gravity.AbsRadAngle;
-	self.Frame = gravity:MagnitudeIsGreaterThan(5) and 0 or 1;
+	local pullForce = (self.Vel + self.PrevVel)/2 - SceneMan.GlobalAcc * rte.PxTravelledPerFrame;
+	self.RotAngle = pullForce.AbsRadAngle;
+	self.Frame = not pullForce:MagnitudeIsGreaterThan(8) and 1 or 0;
 end


### PR DESCRIPTION
   X and 0 or 1 always returned 1 before, resulting in only frame 1's getting used.
   "Gravity" while standing was definitively above 5, going below 5 only in couple ticks of weightlessness after reaching the peak of flight of the related actor, by which point ponytail would be behind the actor 100% of the times, rendering all this pointless, and the bob i just found looked better with 8 in place of 5.