### PR TITLE
A fix and a tweak

### DIFF
--- a/Base.rte/Devices/Special/Medikit/Medikit.lua
+++ b/Base.rte/Devices/Special/Medikit/Medikit.lua
@@ -1,5 +1,5 @@
 function Create(self)
-	self.baseStrength = 10;
+	self.baseStrength = 14;
 
 	self.confirmSound = CreateSoundContainer("Confirm", "Base.rte");
 	self.errorSound = CreateSoundContainer("Error", "Base.rte");
@@ -21,12 +21,14 @@ function Update(self)
 				end
 			end
 			if target and (target.Health < target.MaxHealth or target.WoundCount > 0) then
-				local strength = self.baseStrength + math.ceil(3000/(1 + math.abs(target.Mass - target.InventoryMass + target.Material.StructuralIntegrity) * 0.5));
+				local targetToughnessCoefficient = math.ceil((700/(1 + math.abs(target.Mass - target.InventoryMass + target.Material.StructuralIntegrity)))^1.6);
+				local strength = self.baseStrength + targetToughnessCoefficient;
+				
 				if target.Health < target.MaxHealth then
 					target.Health = math.min(target.Health + strength, target.MaxHealth);
 				end
 				if target.WoundCount > 0 then
-					target:RemoveWounds(math.ceil(strength * 0.15), true, false, false);
+					target:RemoveWounds(math.ceil(strength * 1), true, false, false);
 				end
 				target:FlashWhite(50);
 				self.confirmSound:Play(self.Pos);

--- a/Ronin.rte/Actors/Infantry/RoninLight/Hair.lua
+++ b/Ronin.rte/Actors/Infantry/RoninLight/Hair.lua
@@ -1,5 +1,5 @@
 function Update(self)
 	local pullForce = (self.Vel + self.PrevVel)/2 - SceneMan.GlobalAcc * rte.PxTravelledPerFrame;
 	self.RotAngle = pullForce.AbsRadAngle;
-	self.Frame = not pullForce:MagnitudeIsGreaterThan(8) and 1 or 0;
+	self.Frame = pullForce:MagnitudeIsLessThan(8) and 1 or 0;
 end

--- a/Ronin.rte/Actors/Infantry/RoninLight/Hair.lua
+++ b/Ronin.rte/Actors/Infantry/RoninLight/Hair.lua
@@ -1,5 +1,5 @@
 function Update(self)
-	local gravity = (self.Vel + self.PrevVel)/2 - SceneMan.GlobalAcc * rte.PxTravelledPerFrame;
-	self.RotAngle = gravity.AbsRadAngle;
-	self.Frame = gravity:MagnitudeIsGreaterThan(5) and 0 or 1;
+	local pullForce = (self.Vel + self.PrevVel)/2 - SceneMan.GlobalAcc * rte.PxTravelledPerFrame;
+	self.RotAngle = pullForce.AbsRadAngle;
+	self.Frame = not pullForce:MagnitudeIsGreaterThan(8) and 1 or 0;
 end


### PR DESCRIPTION
Hair.lua:
X and 0 or 1 always returned 1 before, resulting in only frame 1's getting used.
"Gravity" while standing was definitively above 5, going below 5 only in couple ticks of weightlessness after reaching the peak of flight of the related actor, by which point ponytail would be behind the actor 100% of the times, rendering all this pointless, and the bob I just found looked better with 8 in place of 5.

Medikit changes:
Used to heal ~36 points a use for light browncoats and ronin infantry, were absolutely useless at stopping bleeding I doubted wound-closing was implemented for them. It now heals 21 a use for browncoats, 22 for ronin infantry and 26 for dummies, and now (almost) stops really severe bleeding in two uses. I feel that this is a much better dynamic for this kind of item.